### PR TITLE
SCAPI moved from Java to C++ in a different repository

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ Here I tried to reference the most recent article found on specific software sin
 - [APRICOT](https://github.com/bristolcrypto/apricot) - OT Extension secure against malicious adversaries | [2015/546](http://eprint.iacr.org/2015/546).
 - [libOTe](https://github.com/osu-crypto/libOTe) - Library with various OT Extensions.
 - [OT Extension](https://github.com/encryptogroup/OTExtension) - OT Extension secure against malicious adversaries | [2015/061](https://eprint.iacr.org/2015/061).
-- [SCAPI](https://github.com/cryptobiu/scapi) - Various secure computation API's carefully documented with a clean code design in mind | [2012/629](http://eprint.iacr.org/2012/629).
+- [SCAPI](https://github.com/cryptobiu/libscapi) - Various secure computation API's carefully documented with a clean code design in mind | [2012/629](http://eprint.iacr.org/2012/629).
 - [SplitCommit](https://github.com/AarhusCrypto/SplitCommit) - Additively homomorphic commitment scheme | [2015/694](http://eprint.iacr.org/2015/694).
 - [TSS](https://github.com/snipsco/rust-threshold-secret-sharing) - A pure-Rust implementation of various threshold secret sharing schemes.
 


### PR DESCRIPTION
Updated the SCAPI URL to the new repo.

Citing the old SCAPI README:
"(08/01/2018: As of this year, we no longer support project developed over Java scapi. Please use libscapi."