### PR TITLE
Add Vultisig to Apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,7 @@ Here I tried to reference the most recent article found on specific software sin
 - [2PC is for Lovers](https://voltrevo.github.io/2pc-is-for-lovers/) - Allows two people to find out if they are secretly in love with each other using malicious secure 2PC of a single AND gate.
 - [MPC Hello](https://voltrevo.github.io/mpc-hello/) - Malicious secure 2PC calculating the larger of two numbers. Also a [template repository](https://github.com/voltrevo/mpc-hello) for building malicious secure 2PC web apps for any circuit.
 - [TLS Notary](https://tlsnotary.org/) - Uses MPC to blindly sign TLS data, allowing users to make proofs about the content of data served to them over https.
+- [Vultisig](https://vultisig.com/) - Seedless, fully self-custodial multi-chain crypto wallet. The private key is never assembled in one place; key generation and signing run as DKLS23 threshold signatures across the user's own devices. Open source clients for iOS, Android, desktop, and browser.
 
 ### Frameworks
 


### PR DESCRIPTION
The `Apps` section currently lists three demos — two 2PC toy circuits and TLS Notary. Vultisig is a production consumer wallet built on threshold signatures: keygen and signing run DKLS23 across the user's own phones and desktops, and the full key never exists on any single device. It ships on the App Store, Google Play, desktop, and as a browser extension, with all clients Apache-2.0 on GitHub.

I think it earns a spot because it is one of the few places where a general audience touches MPC without knowing it — useful as a "this actually shipped" datapoint next to the research demos. Placed alphabetically after TLS Notary; description is 259 characters and ends with a period.

Docs-only addition — no runtime changes.
